### PR TITLE
Integrate local model support via llama-cpp-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RPG-DiffusionMaster Extension for Stable Diffusion WebUI  
+# RPG-DiffusionMaster Extension for Stable Diffusion WebUI
   
 This repository hosts an extension for [Stable Diffusion WebUI](https://github.com/AUTOMATIC1111/stable-diffusion-webui) that integrates the functionalities of [RPG-DiffusionMaster](https://github.com/YangLing0818/RPG-DiffusionMaster). It brings additional changes and enhancements, enabling users of WebUI to interact with RPG-DiffusionMaster more seamlessly.
   
@@ -28,12 +28,11 @@ Prior to installing this extension, ensure that the [Regional Prompter](https://
   
 ## To-Do List 💪 
   
-- [ ] Integrate local LLM support. 
+- [x] Integrate local LLM support. 
   
 ## Differences from the Official Implementation 
   
-- Adds support for the OpenAI Azure GPT4 Model and Gemini Pro. 
-- Local LLM support is pending. 
+- Adds support for the OpenAI Azure GPT4 Model and Gemini Pro.  
 - Alters the logic to enhance stability when extracting regional prompts. 
   
 ## Acknowledgements 

--- a/install.py
+++ b/install.py
@@ -10,4 +10,4 @@ if not launch.is_installed("llama-cpp-python"):
     if torch.cuda.is_available:
         os.environ["CMAKE_ARGS"] = "-DLLAMA_CUBLAS=on"
         print("Installing llama-cpp with cuda")
-    launch.run_pip("install llama-cpp-python --no-cache-dir")
+    launch.run_pip("install llama-cpp-python==0.2.56", "requirements RPG-DiffusionMaster")

--- a/install.py
+++ b/install.py
@@ -1,6 +1,13 @@
 import launch
+import os
 
 if not launch.is_installed("openai"):
     launch.run_pip("install openai==1.10.0", "requirements RPG-DiffusionMaster")
 if not launch.is_installed("google-generativeai"):
     launch.run_pip("install google-generativeai==0.3.2", "requirements RPG-DiffusionMaster")
+if not launch.is_installed("llama-cpp-python"):
+    import torch
+    if torch.cuda.is_available:
+        os.environ["CMAKE_ARGS"] = "-DLLAMA_CUBLAS=on"
+        print("Installing llama-cpp with cuda")
+    launch.run_pip("install llama-cpp-python --no-cache-dir")

--- a/rpg_lib/rpg_enums.py
+++ b/rpg_lib/rpg_enums.py
@@ -10,3 +10,4 @@ class LLMType(Enum):
     GEMINI_PRO = "gemini-pro"
     GPT4 = "gpt4"
     GPT4_AZURE = "GPT4-AZURE"
+    Local = "Local-Model"


### PR DESCRIPTION
This pr adds support for local models via the llama-cpp-python library. This installs llama-cpp-python as a dependency, if cuda is available on first launch it will install with cuda support, otherwise the cpu only version will be used. The local model option is available in the UI, the path of the gguf file must be entered into the ui by the user as well as the number of layers to offload.

I chose llama-cpp over other libraries because it has the best cpu offloading and an openai compatible completions function. For pure speed exllamav2 would have been better but far less accessible.

Support for the other gpu acceleration methods available in llama-cpp could probably be added but I don't have the hardware to test them.